### PR TITLE
Revert s overflow handling

### DIFF
--- a/hacspec-halfagg/src/halfagg.rs
+++ b/hacspec-halfagg/src/halfagg.rs
@@ -54,8 +54,7 @@ pub fn inc_aggregate(
         let (pk, msg) = pm_aggd[i];
         pmr[i] = (pk, msg, Bytes32::from_slice(aggsig, 32 * i, 32));
     }
-    let mut s = scalar_from_bytes_strict(Bytes32::from_seq(&aggsig.slice(32 * v, 32)))
-        .ok_or(Error::MalformedSignature)?;
+    let mut s = Scalar::from_byte_seq_be(&aggsig.slice(32 * v, 32));
 
     for i in v..v + u {
         let (pk, msg, sig) = pms_to_agg[i - v];
@@ -66,9 +65,7 @@ pub fn inc_aggregate(
         let z = scalar_from_bytes(hash_halfagg(
             &Seq::<(PublicKey, Message, Bytes32)>::from_slice(&pmr, 0, i + 1),
         ));
-        let si = scalar_from_bytes_strict(Bytes32::from_slice(&sig, 32, 32))
-            .ok_or(Error::MalformedSignature)?;
-        s = s + z * si;
+        s = s + z * Scalar::from_byte_seq_be(&Bytes32::from_slice(&sig, 32, 32));
     }
     let mut ret = Seq::<U8>::new(0);
     for i in 0..pmr.len() {

--- a/half-aggregation.mediawiki
+++ b/half-aggregation.mediawiki
@@ -144,10 +144,9 @@ Input:
 * For ''i = v .. v+u-1'':
 ** Let ''(pk<sub>i</sub>, m<sub>i</sub>, sig<sub>i</sub>) = pms_to_agg<sub>i-v</sub>''
 ** Let ''r<sub>i</sub> = sig<sub>i</sub>[0:32]''
-** Let ''s<sub>i</sub> = int(sig<sub>i</sub>[32:64])''; fail if ''s<sub>i</sub> &ge; n''
+** Let ''s<sub>i</sub> = int(sig<sub>i</sub>[32:64])''
 ** Let ''z<sub>i</sub> = int(hash<sub>HalfAgg/randomizer</sub>(r<sub>0</sub> || pk<sub>0</sub> || m<sub>0</sub> || ... || r<sub>i</sub> || pk<sub>i</sub> || m<sub>i</sub>)) mod n''
-* Let ''q = int(aggsig[(v⋅32:(v+1)⋅32]))''; fail if ''q &ge; n''
-* Let ''s = q + z<sub>v</sub>⋅s<sub>v</sub> + ... + z<sub>v+u-1</sub>⋅s<sub>v+u-1</sub> mod n''
+* Let ''s = int(aggsig[(v⋅32:(v+1)⋅32]) + z<sub>v</sub>⋅s<sub>v</sub> + ... + z<sub>v+u-1</sub>⋅s<sub>v+u-1</sub> mod n''
 * Return ''r<sub>0</sub> || ... || r<sub>v+u-1</sub> || bytes(s)''
 
 ==== VerifyAggregate ====

--- a/half-aggregation.mediawiki
+++ b/half-aggregation.mediawiki
@@ -115,7 +115,8 @@ The following conventions are used, with constants as defined for [https://www.s
 ==== Aggregate ====
 
 ''Aggregate'' takes an array of public key, message and signature triples and returns an aggregate signature.
-If for every triple ''(p, m, s)'' we have that ''Verify(p, m, s)'' (as defined in BIP 340) returns true, then the returned aggregate signature and the array of ''(p, m)'' tuples passes ''VerifyAggregate''.
+If every triple ''(p, m, s)'' is valid (i.e., ''Verify(p, m, s)'' as defined in BIP 340 returns true), then the returned aggregate signature and the array of ''(p, m)'' tuples passes ''VerifyAggregate''.
+(However, the inverse does not hold: given suitable valid triples, it is possible to construct an input array to ''Aggregate'' which contains invalid triples, but for which ''VerifyAggregate'' will accept the aggregate signature returned by ''Aggregate''. If this is undesired, input triples should be verified individually before passing them to ''Aggregate''.)
 
 Input:
 * ''pms<sub>0..u-1</sub>'': an array of ''u'' triples, where the first element of each triple is a 32-byte public key, the second element is a 32-byte message and the third element is a 64-byte BIP 340 signature
@@ -128,7 +129,8 @@ Input:
 
 ''IncAggregate'' takes an aggregate signature, an array of public key and message tuples corresponding to the aggregate signature, and an additional array of public key, message and signature triples.
 It aggregates the additional array of triples into the existing aggregate signature and returns the resulting new aggregate signature.
-In other words, if ''VerifyAggregate(aggsig, pm_aggd)'' passes and for every triple ''(p, m, s)'' in ''pms_to_agg'' we have that ''Verify(p, m, s)'' (as defined in BIP 340) returns true, then the returned aggregate signature along with the array of ''(p, m)'' tuples of ''pm_aggd'' and ''pms_to_agg'' passes ''VerifyAggregate''.
+In other words, if ''VerifyAggregate(aggsig, pm_aggd)'' passes and every triple ''(p, m, s)'' in ''pms_to_agg'' is valid (i.e., ''Verify(p, m, s)'' as defined in BIP 340 returns true), then the returned aggregate signature along with the array of ''(p, m)'' tuples of ''pm_aggd'' and ''pms_to_agg'' passes ''VerifyAggregate''.
+(However, the inverse does not hold: given a suitable valid aggregate signature and suitable valid triples, it is possible to construct inputs to ''IncAggregate'' which contain an invalid aggregate signature or invalid triples, but for which ''VerifyAggregate'' will accept the aggregate signature returned by ''IncAggregate''. If this is undesired, the input triples and the input aggregate signature should be verified individually before passing them to ''IncAggregate''.)
 
 Input:
 * ''aggsig'' : a byte array


### PR DESCRIPTION
After some more consideration. I think the original behavior of ignoring overflows in input s values during aggregation was better. It simply removes an error path from the user. (For some background, BIP340 intentionally didn't distinguish between an invalid sig or an unparseable sig. This avoids having two distinct error paths where everyone just needs a single one.) 

One could think that this change now could lead to cases where inputs sigs are invalid (due to overflow in s), but the resulting aggsig is valid. But first, such input sigs are computationally hard to create if the hash function is good, and second, we anyway can't hold up the property that invalid input sigs always produce an invalid aggsig (unless we verify inputs upfront), as we now note in the BIP.