### PR TITLE
BIP Halfagg: Fix two inconsistencies

### DIFF
--- a/hacspec-halfagg/src/halfagg.rs
+++ b/hacspec-halfagg/src/halfagg.rs
@@ -120,7 +120,7 @@ pub fn verify_aggregate(aggsig: &AggSig, pm_aggd: &Seq<(PublicKey, Message)>) ->
             VerifyResult::Err(Error::InvalidSignature)?;
         }
         let r = r_res.unwrap();
-        let e = scalar_from_bytes(hash_challenge(rx, bytes_from_point(p), msg));
+        let e = scalar_from_bytes(hash_challenge(rx, pk, msg));
         pmr[i] = (pk, msg, rx);
         let z = randomizer(&pmr, i);
         terms[2 * i] = (z, r);

--- a/half-aggregation.mediawiki
+++ b/half-aggregation.mediawiki
@@ -123,7 +123,8 @@ Input:
 
 '''''Aggregate(pms<sub>0..u-1</sub>)''''':
 * Let ''aggsig = bytes(0)''
-* Return ''IncAggregate(aggsig, pms<sub>0..u-1</sub>)''; fail if that fails.
+* Let ''pm_aggd'' be an empty array
+* Return ''IncAggregate(aggsig, pm_aggd, pms<sub>0..u-1</sub>)''; fail if that fails.
 
 ==== IncAggregate ====
 


### PR DESCRIPTION
I found two inconsistencies while reviewing/implementing the Halfagg BIP:

1. (pretty minor) The signature of the IncAggregate function is missing the second input parameter `pm_aggd` when called within `Aggregate`.
2. The BIP340 challenge in `VerifyAggregate` is inconsistent between the BIP and the hacspec implementation. The BIP uses `pki`, the 32 bytes public key, while the hacspec implementation uses the corresponding point `Pi`. I wasn't sure which one was the correct way, for now, I updated the BIP but maybe the hacspec implementation is supposed to be fixed instead. Since I was using the test vectors from the hacspec implementation to confirm my code was correct it was just more convenient to assume the hacspec code is correct.

FWIW, my Python implementation can be found can be found here: https://github.com/fjahr/cisa-playground/blob/main/halfagg.py My main goal with this was to review the BIP so I tried to keep it as close to the BIP as possible.