### PR TITLE
halfagg: Remove fixed limit

### DIFF
--- a/hacspec-halfagg/src/halfagg.rs
+++ b/hacspec-halfagg/src/halfagg.rs
@@ -8,7 +8,6 @@ use hacspec_lib::*;
 pub enum Error {
     InvalidPublicKey(usize),
     InvalidSignature,
-    AggSigTooBig,
     MalformedSignature,
 }
 
@@ -54,10 +53,6 @@ pub fn inc_aggregate(
     pm_aggd: &Seq<(PublicKey, Message)>,
     pms_to_agg: &Seq<(PublicKey, Message, Signature)>,
 ) -> AggregateResult {
-    let (sum, overflow) = pm_aggd.len().overflowing_add(pms_to_agg.len());
-    if overflow || sum > 0xffff {
-        AggregateResult::Err(Error::AggSigTooBig)?;
-    }
     if aggsig.len() != 32 * (pm_aggd.len() + 1) {
         AggregateResult::Err(Error::MalformedSignature)?;
     }
@@ -96,9 +91,6 @@ fn point_multi_mul(b: Scalar, terms: &Seq<(Scalar, AffinePoint)>) -> Point {
 
 pub type VerifyResult = Result<(), Error>;
 pub fn verify_aggregate(aggsig: &AggSig, pm_aggd: &Seq<(PublicKey, Message)>) -> VerifyResult {
-    if pm_aggd.len() > 0xffff {
-        VerifyResult::Err(Error::AggSigTooBig)?;
-    }
     if aggsig.len() != 32 * (pm_aggd.len() + 1) {
         VerifyResult::Err(Error::InvalidSignature)?;
     }

--- a/hacspec-halfagg/tests/tests.rs
+++ b/hacspec-halfagg/tests/tests.rs
@@ -198,20 +198,4 @@ fn test_edge_cases() {
         verify_aggregate(&aggsig, &empty_pm).unwrap_err()
             == hacspec_halfagg::Error::InvalidSignature
     );
-
-    let big_pms = Seq::<(PublicKey, Message, Signature)>::new(0xffff + 1);
-    assert!(aggregate(&big_pms).unwrap_err() == hacspec_halfagg::Error::AggSigTooBig);
-    let aggsig = AggSig::new(32);
-    let big_pm = Seq::<(PublicKey, Message)>::new(0xffff + 1);
-    assert!(
-        inc_aggregate(&aggsig, &big_pm, &empty_pms).unwrap_err()
-            == hacspec_halfagg::Error::AggSigTooBig
-    );
-    assert!(
-        inc_aggregate(&aggsig, &empty_pm, &big_pms).unwrap_err()
-            == hacspec_halfagg::Error::AggSigTooBig
-    );
-    assert!(
-        verify_aggregate(&aggsig, &big_pm).unwrap_err() == hacspec_halfagg::Error::AggSigTooBig
-    );
 }

--- a/half-aggregation.mediawiki
+++ b/half-aggregation.mediawiki
@@ -62,7 +62,7 @@ Moreover, they came up with an elegant approach to incremental aggregation that 
 * A half-aggregate signature of ''u'' BIP 340 input signatures is serialized as the ''(u+1)⋅32''-byte array ''r<sub>1</sub> || ... || r<sub>u</sub> || bytes(s)'' where ''r<sub>i</sub>'' is a 32-byte array from input signature ''i'' and ''s'' is a scalar aggregate (see below for details).
 * This document does ''not'' specify the aggregation of multiple aggregate signatures (yet). It is possible, but requires changing the encoding of an aggregate signature. Since it is not possible to undo the aggregation of the s-values, when verifying of such an aggregate signature the randomizers need to be the same as when verifying the individual aggregate signature. Therefore, the aggregate signature needs to encode a tree that reveals how the individual signatures were aggregated and how the resulting aggregate signatures were reaggregated.
 * The first randomizer ''z<sub>0</sub>'' is fixed to the constant ''1'', which speeds up verification because ''z<sub>0</sub>⋅R<sub>0</sub> = R<sub>0</sub>''. This optimization has been suggested and proven secure by [https://eprint.iacr.org/2022/222.pdf Chen and Zhao].
-* The maximum number of signatures that can be aggregated is ''2<sup>16</sup> - 1''. Having a maximum value is supposed to prevent integer overflows. This specific value was a conservative choice and may be raised in the future (TODO).
+* This BIP does not impose a maximum number of signatures that can be aggregated in a single half-aggregate signature. Implementations may enforce limits, e.g., to faciliate testing, to prevent ressource exhaustion and integer overflows. Additionally, applications should enforce a (possibly lower) limit that suits their needs, taking into account that processing large aggregates may take a considerable amount of time. We note that there must be agreement over the limits in consensus-critical applications.
 
 == Description ==
 
@@ -139,7 +139,6 @@ Input:
 * ''pms_to_agg<sub>0..u-1</sub>'': an array of ''u'' triples, where the first element of each tuple is a 32-byte public key, the second element is a 32-byte message and the third element is a 64-byte BIP 340 signature
 
 '''''IncAggregate(aggsig, pm_aggd<sub>0..v-1</sub>, pms_to_agg<sub>0..u-1</sub>)''''':
-* Fail if ''v + u &ge; 2<sup>16</sup>''
 * Fail if ''len(aggsig) &ne; 32 * (v + 1)''
 * For ''i = 0 .. v-1'':
 ** Let ''(pk<sub>i</sub>, m<sub>i</sub>) = pm_aggd<sub>i</sub>''
@@ -165,7 +164,6 @@ Input:
 
 '''''VerifyAggregate(aggsig, pm_aggd<sub>0..u-1</sub>)''''':
 The algorithm ''VerifyAggregate(aggsig, pm_aggd<sub>0..u-1</sub>)'' is defined as:
-* Fail if ''u &ge; 2<sup>16</sup>''
 * Fail if ''len(aggsig) &ne; 32 * (u + 1)''
 * For ''i = 0 .. u-1'':
 ** Let ''(pk<sub>i</sub>, m<sub>i</sub>) = pm_aggd<sub>i</sub>''


### PR DESCRIPTION
This is one way to deal with the limit. My thinking is that we shouldn't be responsible for the limit. 

The drawback of this approach is that it removes some tests. The rust spec is still correct in the sense that you can't possibly have two `Seq`s whose combined size is larger than `usize::MAX` because you won't have enough memory. But that's rather implicit, and it may not be true for implementations using other data types, or in other languages etc. Implementations that want to enforce a limit will have to figure out how to do it, because the spec won't help them.